### PR TITLE
Dev

### DIFF
--- a/io_annocfg/__init__.py
+++ b/io_annocfg/__init__.py
@@ -19,7 +19,7 @@
 bl_info = {
     "name": "Annocfg ImportExport",
     "author": "xormenter",
-    "version": (2, 1, 0),
+    "version": (2, 3, 0),
     "blender": (2, 93, 0),
     "location": "File > Import > Anno (.cfg)",
     "description": "Allows importing and exporting configuration files for Anno 1800 3d models.",

--- a/io_annocfg/anno_objects.py
+++ b/io_annocfg/anno_objects.py
@@ -141,6 +141,18 @@ class Transform:
             return
         for v in object.data.vertices:
             v.co.x *= -1.0
+            
+        #Inverting normals for import AND Export they are wrong because of scaling on the x axis.
+        #Warn people that this will break exports from .blend files made with an earlier version!!!
+        mesh = object.data
+        bm = bmesh.new()
+        bm.from_mesh(mesh) # load bmesh
+        for f in bm.faces:
+             f.normal_flip()
+        bm.normal_update() # not sure if req'd
+        bm.to_mesh(mesh)
+        mesh.update()
+        bm.clear() #.. clear before load next
     
     def apply_to(self, object):
         if self.anno_coords:
@@ -1622,16 +1634,7 @@ class Prop(AnnoObject):
         imported_obj = import_model_to_scene(model_filename)
         if imported_obj is None:
             return add_empty_to_scene()
-        #Todo add inverting normals for import AND Export they are wrong because of scaling on the x axis...
-        # mesh = imported_obj.data
-        # bm = bmesh.new()
-        # bm.from_mesh(mesh) # load bmesh
-        # for f in bm.faces:
-        #     f.normal_flip()
-        # bm.normal_update() # not sure if req'd
-        # bm.to_mesh(mesh)
-        # mesh.update()
-        # bm.clear() #.. clear before load next
+
         
         #materials
         cls.apply_materials_to_object(imported_obj, [material])

--- a/io_annocfg/anno_objects.py
+++ b/io_annocfg/anno_objects.py
@@ -11,6 +11,7 @@ from typing import Tuple, List, NewType, Any, Union, Dict, Optional, TypeVar, Ty
 from abc import ABC, abstractmethod
 from bpy.props import EnumProperty, BoolProperty, PointerProperty, IntProperty, FloatProperty, CollectionProperty, StringProperty, FloatVectorProperty
 from bpy.types import PropertyGroup, Panel, Operator, UIList
+import bmesh
 import sys
 def str_to_class(classname):
     return getattr(sys.modules[__name__], classname)
@@ -389,8 +390,10 @@ class XMLPropertyGroup(PropertyGroup):
                         ]:
             for prop in property_group:
                 value_string = converter.to_string(prop.value)
-                    
-                find_or_create(target_node, prop.tag).text = value_string
+                #It is better to always create a new subelement - otherwise there can only be one of each tag.
+                #Or does this create any problems?
+                #find_or_create(target_node, prop.tag).text = value_string
+                ET.SubElement(target_node, prop.tag).text = value_string
         for dyn_prop in self.dynamic_properties:
             subnode = ET.SubElement(target_node, dyn_prop.tag)
             dyn_prop.to_node(subnode)
@@ -1619,6 +1622,18 @@ class Prop(AnnoObject):
         imported_obj = import_model_to_scene(model_filename)
         if imported_obj is None:
             return add_empty_to_scene()
+        #Todo add inverting normals for import AND Export they are wrong because of scaling on the x axis...
+        # mesh = imported_obj.data
+        # bm = bmesh.new()
+        # bm.from_mesh(mesh) # load bmesh
+        # for f in bm.faces:
+        #     f.normal_flip()
+        # bm.normal_update() # not sure if req'd
+        # bm.to_mesh(mesh)
+        # mesh.update()
+        # bm.clear() #.. clear before load next
+        
+        #materials
         cls.apply_materials_to_object(imported_obj, [material])
         return imported_obj
 

--- a/io_annocfg/anno_objects.py
+++ b/io_annocfg/anno_objects.py
@@ -2190,8 +2190,8 @@ class MainFile(AnnoObject):
 
 anno_object_classes = [
     NoAnnoObject, MainFile, Model, Cf7File,
-    SubFile, Decal, Propcontainer, Prop, Particle, IfoCube, IfoPlane, Sequence, DummyGroup, Spline,
-    Dummy, Cf7DummyGroup, Cf7Dummy, FeedbackConfig,SimpleAnnoFeedbackEncodingObject, ArbitraryXMLAnnoObject, Light, Cloth, Material, IfoFile
+    SubFile, Decal, Propcontainer, Prop, Particle, IfoCube, IfoPlane, Sequence, DummyGroup,
+    Dummy, Cf7DummyGroup, Cf7Dummy, FeedbackConfig,SimpleAnnoFeedbackEncodingObject, ArbitraryXMLAnnoObject, Light, Cloth, Material, IfoFile, Spline
 ]
 
 

--- a/io_annocfg/anno_objects.py
+++ b/io_annocfg/anno_objects.py
@@ -848,7 +848,7 @@ class Material:
         normal_map = self.add_shader_node(anno_shader, "ShaderNodeNormalMap",
                                         position = (5, 2),
                                         default_inputs = {
-                                            0 : 1.0,
+                                            0 : 0.5,
                                         },
                                         inputs = {
                                             "Color" : combine_normal.outputs["Image"],
@@ -1004,11 +1004,13 @@ class Material:
             texture = self.get_texture(texture_path)
             if texture is not None:
                 texture_node.image = texture
+                if "Norm" in texture_name or "Metal" in texture_name or "Height" in texture_name:
+                    texture_node.image.colorspace_settings.name = 'Non-Color'
             texture_node.name = texture_name
             texture_node.label = texture_name
             texture_node.location.x -= 4 * positioning_unit[0] - positioning_offset[0]
             texture_node.location.y -= i * positioning_unit[1] - positioning_offset[1]
-            
+
             texture_node.anno_properties.enabled = self.texture_enabled[texture_name]
             extension = texture_path.suffix
             if extension not in [".png", ".psd"]:
@@ -2142,6 +2144,24 @@ class Spline(AnnoObject):
             spline.bezier_points[i].co.z = transform.location[2]
             spline.bezier_points[i].handle_left_type = "AUTO"
             spline.bezier_points[i].handle_right_type = "AUTO"
+            
+        # obj.data.splines.new("BEZIER")
+        # spline = obj.data.splines[1]
+        # control_points = node.find("ApproximationPoints")
+        # if control_points is None:
+        #     return obj
+        # spline.bezier_points.add(len(control_points))
+        # for i, control_point_node in enumerate(control_points):
+        #     x = get_float(control_point_node, "x")
+        #     y = get_float(control_point_node, "y")
+        #     z = get_float(control_point_node, "z")
+        #     transform = Transform(loc = [x,y,z], anno_coords = True)
+        #     transform.convert_to_blender_coords()
+        #     spline.bezier_points[i].co.x = transform.location[0]
+        #     spline.bezier_points[i].co.y = transform.location[1]
+        #     spline.bezier_points[i].co.z = transform.location[2]
+        #     spline.bezier_points[i].handle_left_type = "AUTO"
+        #     spline.bezier_points[i].handle_right_type = "AUTO"
             
         return obj   
     

--- a/io_annocfg/operators.py
+++ b/io_annocfg/operators.py
@@ -143,6 +143,7 @@ class ExportAnnoCfg(Operator, ExportHelper):
         with open(cf7_filepath, 'w') as f:
             f.write(cf7tree_string)
         if IO_AnnocfgPreferences.get_path_to_fc_converter().exists():
+            print(f"\"{IO_AnnocfgPreferences.get_path_to_fc_converter()}\" -w \"{cf7_filepath}\" -y -o \"{cf7_filepath.with_suffix('.fc')}\"")
             subprocess.call(f"\"{IO_AnnocfgPreferences.get_path_to_fc_converter()}\" -w \"{cf7_filepath}\" -y -o \"{cf7_filepath.with_suffix('.fc')}\"")
         return
 

--- a/io_annocfg/prefs.py
+++ b/io_annocfg/prefs.py
@@ -17,7 +17,7 @@
 # ##### END GPL LICENSE BLOCK #####
 import bpy
 from bpy.types import AddonPreferences, Scene
-from bpy.props import StringProperty, EnumProperty
+from bpy.props import StringProperty, EnumProperty, BoolProperty
 
 from pathlib import Path
 
@@ -28,7 +28,7 @@ class IO_AnnocfgPreferences(AddonPreferences):
         name = "Path to rda Folder",
         description = "Path where you unpacked the Anno rda files. Should contain the data folder.",
         subtype='FILE_PATH',
-        default = "",
+        default = "C:\\Users\\Lars\\Documents\\Anno 1800\\ModdingRDAExplorer-1.4.0.0\\rda",
     )
     path_to_rdm4 : StringProperty( # type: ignore
         name = "Path to rdm4-bin.exe",
@@ -57,7 +57,11 @@ class IO_AnnocfgPreferences(AddonPreferences):
             ("2", "Low", "Low (_2.dss)"),
         ],
         default='0')
-
+    enable_splines : BoolProperty( # type: ignore
+        name = "Import/Export Spline Data (Experimental)",
+        description = "If .fc splines are imported/exported. Currently, only supports ControlPoints",
+        default = False
+    )
     def draw(self, context):
         layout = self.layout
         layout.prop(self, "path_to_rda_folder")
@@ -81,6 +85,9 @@ class IO_AnnocfgPreferences(AddonPreferences):
     @classmethod
     def get_texture_quality(cls):
         return bpy.context.preferences.addons[__package__].preferences.texture_quality
+    @classmethod
+    def splines_enabled(cls):
+        return bpy.context.preferences.addons[__package__].preferences.enable_splines
 
 classes = (
     IO_AnnocfgPreferences,

--- a/io_annocfg/prefs.py
+++ b/io_annocfg/prefs.py
@@ -59,7 +59,7 @@ class IO_AnnocfgPreferences(AddonPreferences):
         default='0')
     enable_splines : BoolProperty( # type: ignore
         name = "Import/Export Spline Data (Experimental)",
-        description = "If .fc splines are imported/exported. Currently, only supports ControlPoints",
+        description = "If .fc splines are imported/exported.",
         default = False
     )
     def draw(self, context):
@@ -69,6 +69,7 @@ class IO_AnnocfgPreferences(AddonPreferences):
         layout.prop(self, "path_to_texconv")
         layout.prop(self, "path_to_fc_converter")
         layout.prop(self, "texture_quality")
+        layout.prop(self, "enable_splines")
 
     @classmethod
     def get_path_to_rda_folder(cls):

--- a/io_annocfg/prefs.py
+++ b/io_annocfg/prefs.py
@@ -28,7 +28,7 @@ class IO_AnnocfgPreferences(AddonPreferences):
         name = "Path to rda Folder",
         description = "Path where you unpacked the Anno rda files. Should contain the data folder.",
         subtype='FILE_PATH',
-        default = "C:\\Users\\Lars\\Documents\\Anno 1800\\ModdingRDAExplorer-1.4.0.0\\rda",
+        default = "",
     )
     path_to_rdm4 : StringProperty( # type: ignore
         name = "Path to rdm4-bin.exe",


### PR DESCRIPTION
Adds experimental spline support (to be enabled in prefs)
Fixes normal, metal and height map color space (to non-color data).
Normals will flipped when mirroring the objects for import/export. 

IMPORTANT: When exporting models from older .blend files, they will have inverted normals. Flip them before exporting.