### PR TITLE
Blender 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ When used with the rdm4 converter and texconv, it will automatically convert .rd
 This means that if you have all those tools, you don't have to convert anything manually and can edit everything directly in Blender.
 
 # Requirements
-Blender **v.2.93** (Both lower and higher versions of blender cause issues!)
+- Blender **3** https://www.blender.org/
+
+**If not using v.3.2+, you'll need to update the gltf importer addon manually!** (A required fix for a bug will only come with the blender 3.2 installer.) For this, download the repository from https://github.com/KhronosGroup/glTF-Blender-IO and overwrite the `io_scene_gltf_2`addon folder in your blender installation. 
+
 To use the automatic conversion, you need:
 - rdm4 converter https://github.com/lukts30/rdm4
 - texconv.exe https://github.com/microsoft/DirectXTex
@@ -18,7 +21,9 @@ And of course the .rda explorer to unpack the game files: https://github.com/lys
 3. If you haven't done so already, **unpack the .rda files** (at least the data/graphics part of it) into a single folder. It should look something like this: `C:\whatever\somewhere\rda\data\graphics\...`.  
 4. In the addon preferences, set the **rda path** to the folder that **contains** your `data` folder with the unpacked rda files. In this example, that would be `C:\whatever\somewhere\rda`
 5. Specify the paths to the `texconv.exe`, `rdm4-bin.exe`, `AnnoFCConverter.exe` executables.
-You are now ready to go!
+
+You are now ready to go! Optional: Set up the prop asset library (See below)
+
 
 # Usage
 ## Importing 
@@ -68,4 +73,15 @@ To use it:
 ![Blender 08_01_2022 23_31_12](https://user-images.githubusercontent.com/94999291/148662128-756104d4-bf6d-4ce1-8b38-347f6136be44.png)
 
 7. Finally, when exporting the MAIN_FILE object, select the FeedbackType SimpleAnnnoFeedbackEncoding. It will write a .xml file, convert it to .cf7 and convert that to .fc. 
+
+
+# Asset Library
+## Setup 
+To set up  the prop asset library, create a fresh .blend file. Click the `File->Import Anno Prop Asset` button. The addon will now load *all* prop assets located somewhere in your .rda folder into this file. This will take a long time (go for a walk, watch a movie, sleep). After that save this .blend file in a user-library directory. The default one is `C:\Users\<USERNAME>\Documents\Blender\Assets` (but you can add more in the blender preferences). Now every prop is marked as an asset and tagged with more or less useful tags. If you want, you can further categorize the props (I suggest to at least put everything into a "Props" category). Close this file.
+
+You might also want to have other objects in your asset browser. Unfortunately, the asset browser can only handle single objects, no hierarchies (at least for now). Therefore, only Models, Props, Lights, Particles, etc. but not Files are valid objects. 
+If you want f.e. to use all the models you made somewhere in all your project files, just save all your .blend files in the same user-library directory and mark the models you want as assets. I'd suggest to add a duplicate of them that has no parent object as asset (to avoid confusion). So you can just extract all kinds of nice parts from the vanilla models, save them in your asset library and then use them whereever you want. 
+
+## Usage
+Now you can use this library in other .blend files. For this, open the asset browser and select the user library you used. Drag and drop the assets into your scene. **Important: You'll need to set the parent (propcontainer) for each prop you add, otherwise your props won't know where they belong and won't be exported!** 
 

--- a/io_annocfg/__init__.py
+++ b/io_annocfg/__init__.py
@@ -19,8 +19,8 @@
 bl_info = {
     "name": "Annocfg ImportExport",
     "author": "xormenter",
-    "version": (2, 3, 0),
-    "blender": (2, 93, 0),
+    "version": (2, 5, 0),
+    "blender": (3, 1, 0),
     "location": "File > Import > Anno (.cfg)",
     "description": "Allows importing and exporting configuration files for Anno 1800 3d models.",
     "doc_url": "https://github.com/xormenter/Blender-Anno-.cfg-Import-Addon",

--- a/io_annocfg/anno_objects.py
+++ b/io_annocfg/anno_objects.py
@@ -499,6 +499,7 @@ class PT_AnnoObjectPropertyPanel(Panel):
         row.enabled = False
         if "Cf7" in obj.anno_object_class_str:
             col.operator(ConvertCf7DummyToDummy.bl_idname, text = "Convert to SimpleAnnoFeedback")
+        col.prop(obj, "parent")
         dyn = obj.dynamic_properties
         dyn.draw(col)
 
@@ -1424,7 +1425,9 @@ class AnnoObject(ABC):
             config_type = cls.__name__
         file_name = Path(get_text(node, "FileName", "")).stem
         name = get_text(node, "Name", file_name)
-        return config_type + "_" + name
+        if not name.startswith(config_type + "_"):
+            name = config_type + "_" + name
+        return name
     
     
     @classmethod

--- a/io_annocfg/anno_objects.py
+++ b/io_annocfg/anno_objects.py
@@ -121,22 +121,34 @@ class Transform:
     def convert_to_blender_coords(self):
         if not self.anno_coords:
             return
-        self.location = (-self.location[0], -self.location[2], self.location[1])
-        self.rotation = (self.rotation[0], self.rotation[1], self.rotation[3], -self.rotation[2])
+        if IO_AnnocfgPreferences.mirror_models():
+            self.location = (-self.location[0], -self.location[2], self.location[1])
+            self.rotation = (self.rotation[0], self.rotation[1], self.rotation[3], -self.rotation[2])
+        else:     
+            self.location = (self.location[0], -self.location[2], self.location[1])
+            self.rotation = (self.rotation[0], self.rotation[1], self.rotation[3], self.rotation[2])
         self.rotation_euler = (self.rotation_euler[0], self.rotation_euler[2], self.rotation_euler[1])
         self.scale = (self.scale[0], self.scale[2], self.scale[1])
+        
         self.anno_coords = False
 
     def convert_to_anno_coords(self):
         if self.anno_coords:
             return
-        self.location = (-self.location[0], self.location[2], -self.location[1])
-        self.rotation = (self.rotation[0], self.rotation[1], -self.rotation[3], self.rotation[2])
+        if IO_AnnocfgPreferences.mirror_models():
+            self.location = (-self.location[0], self.location[2], -self.location[1])
+            self.rotation = (self.rotation[0], self.rotation[1], -self.rotation[3], self.rotation[2])
+        else:     
+            self.location = (self.location[0], -self.location[2], self.location[1])
+            self.rotation = (self.rotation[0], self.rotation[1], self.rotation[3], self.rotation[2])
         self.rotation_euler = (self.rotation_euler[0], self.rotation_euler[2], self.rotation_euler[1])
         self.scale = (self.scale[0], self.scale[2], self.scale[1])
+        
         self.anno_coords
     
     def mirror_mesh(self, object):
+        if not IO_AnnocfgPreferences.mirror_models():
+            return
         if not object.data or not hasattr(object.data, "vertices"):
             return
         for v in object.data.vertices:
@@ -1224,7 +1236,9 @@ def convert_to_glb_if_required(data_path: Union[str, Path]):
         convert_to_glb(fullpath)
 
 def import_model_to_scene(data_path: Union[str, Path, None]) -> BlenderObject:
+    print(data_path)
     if not data_path:
+        print("invalid data path")
         return add_empty_to_scene()
     fullpath = data_path_to_absolute_path(data_path)
     convert_to_glb_if_required(fullpath)
@@ -1235,8 +1249,12 @@ def import_model_to_scene(data_path: Union[str, Path, None]) -> BlenderObject:
     if not fullpath.exists():
         #self.report({'INFO'}, f"Missing file: Cannot find glb model {data_path}.")
         return None
+    # bpy.context.view_layer.objects.active = None
+    # for obj in bpy.data.objects:
+    #     obj.select_set(False)
     ret = bpy.ops.import_scene.gltf(filepath=str(fullpath))
     obj = bpy.context.active_object
+    print(obj.name, obj.type)
     return obj
 
 def add_empty_to_scene(empty_type: str = "SINGLE_ARROW") -> BlenderObject:
@@ -1313,9 +1331,8 @@ class AnnoObject(ABC):
         
     @classmethod
     def xml_to_blender(cls: Type[T], node: ET.Element, parent_object = None) -> BlenderObject:
-        obj = cls().add_blender_object_to_scene(node)
+        obj = cls.add_blender_object_to_scene(node)
         set_anno_object_class(obj, cls)
-        
         obj.name = cls.blender_name_from_node(node)
         if cls.has_name:
             get_text_and_delete(node, "Name")
@@ -1432,18 +1449,48 @@ class AnnoObject(ABC):
             materials (List[Material]): The materials.
         """
         
-        if not obj.data or not obj.data.materials:
+        if not obj.data:
+            #or not obj.data.materials:
             return
+        if len(materials) > 1 and all([bool(re.match( "Material_[0-9]+.*",m.name)) for m in obj.data.materials]):
+            sorted_materials = sorted([mat.name for i, mat in enumerate(obj.data.materials)])
+            if sorted_materials != [mat.name for mat in obj.data.materials]:
+                
+                print("Imported .glb with unordered but enumerated materials. Sorting the slots.")
+                print("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+                print(sorted_materials)
+                for sorted_index, mat_name in enumerate(sorted_materials):
+                    index = 0
+                    for i, mat in enumerate(obj.data.materials):
+                        index = i
+                        if mat.name == mat_name:
+                            break
+                    bpy.context.object.active_material_index = index
+                    for _ in range(len(obj.data.materials)):
+                        bpy.ops.object.material_slot_move(direction='DOWN')
+
+        missing_slots = len(materials) - len(obj.data.materials)
+        if missing_slots > 0:
+            for i in range(missing_slots):
+                obj.data.materials.append(bpy.data.materials.new(name="NewSlotMaterial"))
         for i, material in enumerate(materials):
             if not material:
                 continue
-            if i < len(obj.data.materials):
-                old_material = obj.data.materials[i]
-                obj.data.materials[i] = material.as_blender_material()
-                old_material.user_clear()
-                bpy.data.materials.remove(old_material)
-            else:
-                obj.data.materials.append(material.as_blender_material())
+            slot = i
+            old_material = obj.data.materials[slot]
+            obj.data.materials[slot] = material.as_blender_material()
+            old_material.user_clear()
+            bpy.data.materials.remove(old_material)
+        # for i, material in enumerate(materials):
+        #     if not material:
+        #         continue
+        #     if i < len(obj.data.materials):
+        #         old_material = obj.data.materials[i]
+        #         obj.data.materials[i] = material.as_blender_material()
+        #         old_material.user_clear()
+        #         bpy.data.materials.remove(old_material)
+        #     else:
+        #         obj.data.materials.append(material.as_blender_material())
         
 
 
@@ -1552,6 +1599,13 @@ class SubFile(AnnoObject):
 class Decal(AnnoObject):
     has_transform = True
     transform_paths = {
+        "location.x":"Transformer/Config[ConfigType = 'ORIENTATION_TRANSFORM']/Position.x",
+        "location.y":"Transformer/Config[ConfigType = 'ORIENTATION_TRANSFORM']/Position.y",
+        "location.z":"Transformer/Config[ConfigType = 'ORIENTATION_TRANSFORM']/Position.z",
+        "rotation.x":"Transformer/Config[ConfigType = 'ORIENTATION_TRANSFORM']/Rotation.x",
+        "rotation.y":"Transformer/Config[ConfigType = 'ORIENTATION_TRANSFORM']/Rotation.y",
+        "rotation.z":"Transformer/Config[ConfigType = 'ORIENTATION_TRANSFORM']/Rotation.z",
+        "rotation.w":"Transformer/Config[ConfigType = 'ORIENTATION_TRANSFORM']/Rotation.w",
         "scale.x":"Extents.x",
         "scale.y":"Extents.y",
         "scale.z":"Extents.z",

--- a/io_annocfg/prefs.py
+++ b/io_annocfg/prefs.py
@@ -62,6 +62,12 @@ class IO_AnnocfgPreferences(AddonPreferences):
         description = "If .fc splines are imported/exported.",
         default = False
     )
+    mirror_models_bool : BoolProperty( # type: ignore
+        name = "Mirror along X",
+        description = "The anno engine mirrors object along the X axis. When enabled, the addon will also mirror meshes along the X axis s.t. text is displayed correctly. However, this means that all .glb files imported directly (using the .glb import instead of the .rmd import) will have the wrong orientation, to avoid this uncheck this box. Keep in mind that when you change this setting, all your exising .blend files will not export properly.",
+        default = True
+    )
+    
     def draw(self, context):
         layout = self.layout
         layout.prop(self, "path_to_rda_folder")
@@ -69,6 +75,7 @@ class IO_AnnocfgPreferences(AddonPreferences):
         layout.prop(self, "path_to_texconv")
         layout.prop(self, "path_to_fc_converter")
         layout.prop(self, "texture_quality")
+        layout.prop(self, "mirror_models_bool")
         layout.prop(self, "enable_splines")
 
     @classmethod
@@ -89,6 +96,9 @@ class IO_AnnocfgPreferences(AddonPreferences):
     @classmethod
     def splines_enabled(cls):
         return bpy.context.preferences.addons[__package__].preferences.enable_splines
+    @classmethod
+    def mirror_models(cls):
+        return bpy.context.preferences.addons[__package__].preferences.mirror_models_bool
 
 classes = (
     IO_AnnocfgPreferences,


### PR DESCRIPTION
Support for Blender 3.
- Asset Browser support (Import all Props as Assets)
- Fix material order 
- Mirroring along X can be disabled
- Fix decals not being rotated
- Show parent in AnnoObject tab
- Fix auto generated names having the config type twice