### PR TITLE
Version 3.3

### DIFF
--- a/io_annocfg/__init__.py
+++ b/io_annocfg/__init__.py
@@ -19,7 +19,7 @@
 bl_info = {
     "name": "Annocfg ImportExport",
     "author": "xormenter",
-    "version": (3, 2, 0),
+    "version": (3, 3, 0),
     "blender": (3, 1, 0),
     "location": "File > Import > Anno (.cfg)",
     "description": "Allows importing and exporting configuration files for Anno 1800 3d models.",

--- a/io_annocfg/__init__.py
+++ b/io_annocfg/__init__.py
@@ -19,7 +19,7 @@
 bl_info = {
     "name": "Annocfg ImportExport",
     "author": "xormenter",
-    "version": (3, 0, 1),
+    "version": (3, 1, 0),
     "blender": (3, 1, 0),
     "location": "File > Import > Anno (.cfg)",
     "description": "Allows importing and exporting configuration files for Anno 1800 3d models.",

--- a/io_annocfg/__init__.py
+++ b/io_annocfg/__init__.py
@@ -19,7 +19,7 @@
 bl_info = {
     "name": "Annocfg ImportExport",
     "author": "xormenter",
-    "version": (3, 1, 0),
+    "version": (3, 2, 0),
     "blender": (3, 1, 0),
     "location": "File > Import > Anno (.cfg)",
     "description": "Allows importing and exporting configuration files for Anno 1800 3d models.",

--- a/io_annocfg/__init__.py
+++ b/io_annocfg/__init__.py
@@ -19,7 +19,7 @@
 bl_info = {
     "name": "Annocfg ImportExport",
     "author": "xormenter",
-    "version": (3, 0, 0),
+    "version": (3, 0, 1),
     "blender": (3, 1, 0),
     "location": "File > Import > Anno (.cfg)",
     "description": "Allows importing and exporting configuration files for Anno 1800 3d models.",

--- a/io_annocfg/anno_object_ui.py
+++ b/io_annocfg/anno_object_ui.py
@@ -392,6 +392,16 @@ class DuplicateDummy(Operator):
         bpy.context.view_layer.objects.active = duplicate
         return {'FINISHED'}
 
+class CreateGameObjectFromFile(Operator):
+    """Creates a game-object entry for this object. You still need to specify the id, guid, var_id, and all other important stuff yourself."""
+    bl_idname = "object.make_game_object"
+    bl_label = "Make Game Object (Island Editor)"
+
+    def execute(self, context):
+        obj = context.active_object
+        game_obj = GameObject.parent_for_subfile(obj)
+        return {'FINISHED'}    
+
 
 class ConvertToXML(Operator):
     """Converts the selected object into xml and copies it to the clipboard."""
@@ -582,8 +592,10 @@ class InstancedCollectionToSubFile(Operator):
             return False
         if obj.instance_collection is None:
             return False
+    
         if obj.instance_collection.asset_data is None:
             return False
+
         return "data" in obj.instance_collection.asset_data.description
 
 class LoadAnimations(Operator):
@@ -861,6 +873,9 @@ class PT_AnnoObjectPropertyPanel(Panel):
             col.operator(DuplicateAnnoObject.bl_idname, text = "Duplicate Anno Object")
         if not "NoAnnoObject" == obj.anno_object_class_str:
             col.operator(ConvertToXML.bl_idname, text = "Convert To XML")
+            
+        if "MainFile" in obj.anno_object_class_str or "SubFile" in obj.anno_object_class_str and obj.parent is None:
+            col.operator(CreateGameObjectFromFile.bl_idname, text = CreateGameObjectFromFile.bl_label)
         col.prop(obj, "parent")
 
         dyn = obj.dynamic_properties
@@ -943,6 +958,7 @@ classes = [
     DuplicateAnnoObject,
     DuplicateDummy,
     ConvertToXML,
+    CreateGameObjectFromFile,
     ShowSequence,
     ShowModel,
     MakeCollectionInstanceReal,

--- a/io_annocfg/anno_object_ui.py
+++ b/io_annocfg/anno_object_ui.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 import bpy
 from bpy.types import Object as BlenderObject
 import xml.etree.ElementTree as ET
@@ -391,7 +391,20 @@ class DuplicateDummy(Operator):
         duplicate.select_set(True)
         bpy.context.view_layer.objects.active = duplicate
         return {'FINISHED'}
-    
+
+
+class ConvertToXML(Operator):
+    """Converts the selected object into xml and copies it to the clipboard."""
+    bl_idname = "object.convert_to_xml"
+    bl_label = "Convert To XML"
+
+    def execute(self, context):
+        obj = context.active_object
+        node = get_anno_object_class(obj).blender_to_xml(obj, None, None)
+        ET.indent(node, space="\t", level=0)
+        xmlstr = ET.tostring(node, encoding='utf8', method='xml').replace("<?xml version='1.0' encoding='utf8'?>\n", "")
+        bpy.context.window_manager.clipboard = xmlstr
+        return {'FINISHED'}    
 
 class AddFeedbackDummy(Operator):
     """Adds a properly named dummy to the group."""
@@ -845,7 +858,8 @@ class PT_AnnoObjectPropertyPanel(Panel):
             col.operator(FixDummyName.bl_idname, text = "Fix Dummy Name")
         elif not "NoAnnoObject" == obj.anno_object_class_str:
             col.operator(DuplicateAnnoObject.bl_idname, text = "Duplicate Anno Object")
-
+        if not "NoAnnoObject" == obj.anno_object_class_str:
+            col.operator(ConvertToXML.bl_idname, text = "Convert To XML")
         col.prop(obj, "parent")
 
         dyn = obj.dynamic_properties
@@ -927,6 +941,7 @@ classes = [
     LoadAllAnimations,
     DuplicateAnnoObject,
     DuplicateDummy,
+    ConvertToXML,
     ShowSequence,
     ShowModel,
     MakeCollectionInstanceReal,

--- a/io_annocfg/anno_object_ui.py
+++ b/io_annocfg/anno_object_ui.py
@@ -626,7 +626,11 @@ class MakeCollectionInstanceReal(Operator):
     bl_label = "Make Collection Instance Real"
 
     def execute(self, context):
-        bpy.ops.object.duplicates_make_real(use_base_parent=False, use_hierarchy=True)
+        obj = bpy.context.active_object
+        bpy.ops.object.duplicates_make_real(use_base_parent=True, use_hierarchy=True)
+        for child in obj.children:
+            child.parent = obj.parent
+        bpy.data.objects.remove(obj, do_unlink=True)
         return {'FINISHED'}
     
     @classmethod

--- a/io_annocfg/anno_object_ui.py
+++ b/io_annocfg/anno_object_ui.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 import bpy
 from bpy.types import Object as BlenderObject
 import xml.etree.ElementTree as ET
@@ -402,7 +402,8 @@ class ConvertToXML(Operator):
         obj = context.active_object
         node = get_anno_object_class(obj).blender_to_xml(obj, None, None)
         ET.indent(node, space="\t", level=0)
-        xmlstr = ET.tostring(node, encoding='utf8', method='xml').replace("<?xml version='1.0' encoding='utf8'?>\n", "")
+        xmlstr = ET.tostring(node, encoding='utf8', method='xml')
+        xmlstr = xmlstr.replace("<?xml version='1.0' encoding='utf8'?>\n".encode(), "".encode())
         bpy.context.window_manager.clipboard = xmlstr
         return {'FINISHED'}    
 

--- a/io_annocfg/anno_objects.py
+++ b/io_annocfg/anno_objects.py
@@ -1586,9 +1586,10 @@ class IslandFile:
         else:
             print("Island missing PropGrid")
             print(node.find("PropGrid"))
-            
         #delete the blueprint props
         for prop_obj in prop_objects:
+            if prop_obj is None:
+                continue
             bpy.data.objects.remove(prop_obj, do_unlink=True)
         return obj
 

--- a/io_annocfg/anno_objects.py
+++ b/io_annocfg/anno_objects.py
@@ -714,6 +714,7 @@ class Decal(AnnoObject):
         obj = bpy.context.active_object
         for v in obj.data.vertices:
             v.co.y *= -1.0
+            v.co.x *= -1.0
         return obj   
     
     @classmethod
@@ -1040,7 +1041,7 @@ class IfoMeshHeightmap(AnnoObject):
         mesh.from_pydata(verts, [], [])
         for i, vert in enumerate(obj.data.vertices):
             vert.co.y *= -1
-            
+            vert.co.x *= -1
         return obj
 
     @classmethod 

--- a/io_annocfg/anno_objects.py
+++ b/io_annocfg/anno_objects.py
@@ -1481,7 +1481,7 @@ class PropGridInstance:
         return obj
     
     @classmethod
-    def blender_to_xml(cls, obj):
+    def blender_to_xml(cls, obj, parent = None, child_map = None):
         base_node = obj.dynamic_properties.to_node(ET.Element("None"))
         node = ET.Element("None")
 
@@ -1514,7 +1514,7 @@ class IslandFile:
         file_obj = add_empty_to_scene()  
         return file_obj
     @classmethod
-    def blender_to_xml(cls, obj):
+    def blender_to_xml(cls, obj, parent = None, child_map = None):
         """Only exports the prop grid. Not the heighmap or the prop FileNames."""
         base_node = ET.fromstring(obj["islandxml"])
         
@@ -1578,6 +1578,9 @@ class IslandFile:
             terrain_obj.location.x -= grid_width*unit_scale/2
             terrain_obj.location.y -= grid_width*unit_scale/2
             terrain_obj.rotation_euler[2] = radians(90.0)
+            
+           
+            
         if prop_import_mode == "None":
             return obj
         filenames_node = node.find("PropGrid/FileNames")
@@ -1772,7 +1775,7 @@ class GameObject:
         return obj
     
     @classmethod
-    def blender_to_xml(cls, obj):
+    def blender_to_xml(cls, obj, parent = None, child_map = None):
         node = obj.dynamic_properties.to_node(ET.Element("None"))
         node.find("ID").text = node.find("ID").text.replace("ID_", "")
         

--- a/io_annocfg/anno_objects.py
+++ b/io_annocfg/anno_objects.py
@@ -58,6 +58,7 @@ def import_model_to_scene(data_path: Union[str, Path, None]) -> BlenderObject:
     ret = bpy.ops.import_scene.gltf(filepath=str(fullpath))
     obj = bpy.context.active_object
     print(obj.name, obj.type)
+    Transform.mirror_mesh(obj)
     return obj
 
 def convert_animation_to_glb(model_fullpath, animation_fullpath: Path):
@@ -96,6 +97,7 @@ def import_animated_model_to_scene(model_data_path: Union[str, Path, None], anim
     ret = bpy.ops.import_scene.gltf(filepath=str(combined_path))
     obj = bpy.context.active_object
     print(obj.name, obj.type)
+    Transform.mirror_mesh(obj)
     return obj
 
 def add_empty_to_scene(empty_type: str = "SINGLE_ARROW") -> BlenderObject:

--- a/io_annocfg/anno_objects.py
+++ b/io_annocfg/anno_objects.py
@@ -1412,6 +1412,8 @@ class PropGridInstance:
             o.empty_display_type = 'ARROWS'   
             return o
         prop_obj = prop_objects[index]
+        if prop_obj is None:
+            return None
         copy = prop_obj.copy()
         bpy.context.scene.collection.objects.link(copy)
         return copy
@@ -1431,6 +1433,8 @@ class PropGridInstance:
         </None>
         """
         obj = cls.add_blender_object_to_scene(node, prop_objects)
+        if obj is None:
+            return
         if parent_obj:
             obj.parent = parent_obj
         
@@ -1522,7 +1526,7 @@ class IslandFile:
         return base_node
     
     @classmethod
-    def xml_to_blender(cls, node: ET.Element) -> BlenderObject:
+    def xml_to_blender(cls, node: ET.Element, prop_import_mode) -> BlenderObject:
         obj = cls.add_blender_object_to_scene(node)
         obj["islandxml"] = ET.tostring(node)
         obj.name = "ISLAND_FILE"
@@ -1550,12 +1554,16 @@ class IslandFile:
             terrain_obj.location.x -= grid_width*unit_scale/2
             terrain_obj.location.y -= grid_width*unit_scale/2
             terrain_obj.rotation_euler[2] = radians(90.0)
-            
+        if prop_import_mode == "None":
+            return obj
         filenames_node = node.find("PropGrid/FileNames")
         prop_objects = []
         if filenames_node is not None:
             for i, file_node in enumerate(list(filenames_node)):
                 data_path = file_node.text
+                if prop_import_mode == "No Vegetation" and "vegetation" in data_path:
+                    prop_objects.append(None)
+                    continue
                 prop_xml_node = ET.fromstring(f"""
                             <Config>
                                 <ConfigType>PROP</ConfigType>

--- a/io_annocfg/anno_objects.py
+++ b/io_annocfg/anno_objects.py
@@ -437,7 +437,7 @@ class Track(AnnoObject):
     @classmethod
     def node_to_property_node(self, node, obj):
         for track_node in node.findall("TrackElement"):
-            if get_text(track_node, "Type", "-1") != "0":
+            if get_text(track_node, "Type", "-1") not in  ["0", "1"]:
                 continue
             model_id = int(get_text(track_node, "ModelID", "-1"))
             main_file = obj.parent.parent.parent
@@ -539,7 +539,9 @@ class Model(AnnoObject):
         data_path = get_text(node, "FileName")
         imported_obj = import_model_to_scene(data_path)
         if imported_obj is None:
-            return add_empty_to_scene()
+            bpy.ops.mesh.primitive_cube_add(size = 0.1, location=(0,0,0))
+            obj = bpy.context.active_object
+            return obj
         return imported_obj
     
     @classmethod

--- a/io_annocfg/anno_objects.py
+++ b/io_annocfg/anno_objects.py
@@ -226,7 +226,11 @@ class AnnoObject(ABC):
     @classmethod
     def add_children_from_obj(cls, obj, node, child_map):
         container_name_by_subclass = {subcls : container_name for container_name, subcls in cls.child_anno_object_types.items()}
-        for child_obj in child_map.get(obj.name, []):
+        children = obj.children
+        if child_map is not None:
+            #ToDo: Do not use child map if it is not necessary. I think there were problems with obj.children, but i do not remember them.
+            children = child_map.get(obj.name, [])
+        for child_obj in children:
             subcls = get_anno_object_class(child_obj)
             if subcls == NoAnnoObject:
                 continue
@@ -540,14 +544,22 @@ class Model(AnnoObject):
         if node.find("Animations") is not None:
             return
         #Animations may have been loaded.
-        for child_obj in child_map.get(obj.name, []):
+        children = obj.children
+        if child_map is not None:
+            #ToDo: Do not use child map if it is not necessary. I think there were problems with obj.children, but i do not remember them.
+            children = child_map.get(obj.name, [])
+        for child_obj in children:
             subcls = get_anno_object_class(child_obj)
             if subcls != AnimationsNode:
                 continue
             animations_container = child_obj
             animations_node = find_or_create(node, "Animations")
             anim_nodes = []
-            for anim_obj in child_map.get(animations_container.name, []):
+            anim_children = animations_container.children
+            if child_map is not None:
+                #ToDo: Do not use child map if it is not necessary. I think there were problems with obj.children, but i do not remember them.
+                anim_children = child_map.get(animations_container.name, [])
+            for anim_obj in anim_children:
                 subcls = get_anno_object_class(anim_obj)
                 if subcls != Animation:
                     continue
@@ -830,7 +842,11 @@ class IfoFile(AnnoObject):
     
     @classmethod
     def add_children_from_obj(cls, obj, node, child_map):
-        for child_obj in child_map.get(obj.name, []):
+        children = obj.children
+        if child_map is not None:
+            #ToDo: Do not use child map if it is not necessary. I think there were problems with obj.children, but i do not remember them.
+            children = child_map.get(obj.name, [])
+        for child_obj in children:
             subcls = get_anno_object_class(child_obj)
             if subcls == NoAnnoObject:
                 continue
@@ -1036,7 +1052,11 @@ class DummyGroup(AnnoObject):
 
     @classmethod
     def add_children_from_obj(cls, obj, node, child_map):
-        for child_obj in child_map.get(obj.name, []):
+        children = obj.children
+        if child_map is not None:
+            #ToDo: Do not use child map if it is not necessary. I think there were problems with obj.children, but i do not remember them.
+            children = child_map.get(obj.name, [])
+        for child_obj in children:
             subcls = get_anno_object_class(child_obj)
             if subcls == NoAnnoObject:
                 continue
@@ -1254,7 +1274,11 @@ class Cf7File(AnnoObject):
     @classmethod
     def add_children_from_obj(cls, obj, node, child_map):
         dummy_groups_node = find_or_create(node, "DummyRoot/Groups")
-        for child_obj in child_map.get(obj.name, []):
+        children = obj.children
+        if child_map is not None:
+            #ToDo: Do not use child map if it is not necessary. I think there were problems with obj.children, but i do not remember them.
+            children = child_map.get(obj.name, [])
+        for child_obj in children:
             subcls = get_anno_object_class(child_obj)
             if subcls != Cf7DummyGroup:
                 continue
@@ -1262,7 +1286,7 @@ class Cf7File(AnnoObject):
         if not IO_AnnocfgPreferences.splines_enabled():
             return
         spline_data_node = find_or_create(node, "SplineData")
-        for spline_obj in child_map.get(obj.name, []):
+        for spline_obj in children:
             subcls = get_anno_object_class(spline_obj)
             if subcls != Spline:
                 continue

--- a/io_annocfg/feedback_ui.py
+++ b/io_annocfg/feedback_ui.py
@@ -362,6 +362,12 @@ class FEEDBACK_OT_LoadFeedbackUnit(Operator):
         
         unit_obj = self.import_cfg_file(data_path_to_absolute_path(cfg), "FeedbackUnit_"+name)
         bpy.context.view_layer.objects.active = unit_obj
+        
+        #If the model was loaded from cache, it only is an instanced collection
+        if unit_obj.instance_collection is not None:
+            print("Loaded feedback unit from cache, making it real.")
+            bpy.ops.object.make_hierarchical_collection_instance_real()
+        
         bpy.ops.object.load_all_animations()
         # bpy.context.view_layer.objects.active = unit_obj
         # bpy.ops.object.ShowSequence()

--- a/io_annocfg/material.py
+++ b/io_annocfg/material.py
@@ -201,11 +201,13 @@ class Material:
         texture_path = Path(texture_path)
         texture_path = Path(texture_path.parent, texture_path.stem + self.texture_quality_suffix()+".dds")
         png_file = texture_path.with_suffix(".png")
-        image = bpy.data.images.get(str(png_file.name), None)
-        if image is not None:
-            return image
         fullpath = data_path_to_absolute_path(texture_path)
         png_fullpath = data_path_to_absolute_path(png_file)
+        image = bpy.data.images.get(str(png_file.name), None)
+        if image is not None:
+            image_path_full = os.path.normpath(bpy.path.abspath(image.filepath, library=image.library))
+            if str(image_path_full) == str(png_fullpath):
+                return image
         if not png_fullpath.exists():
             success = self.convert_to_png(fullpath)
             if not success:

--- a/io_annocfg/operators.py
+++ b/io_annocfg/operators.py
@@ -927,6 +927,7 @@ class ImportAllCfgsOperator(Operator, ImportHelper):
         rda_path = IO_AnnocfgPreferences.get_path_to_rda_folder()
         if not dirpath.is_relative_to(rda_path):
             self.report({'ERROR_INVALID_INPUT'}, f"Invalid folder. Needs to be inside your rda folder.")
+            print(f"{dirpath}, {rda_path}, {dirpath.is_relative_to(rda_path)}")
             return {"CANCELLED"}
         if not dirpath.is_dir():
             self.report({'ERROR_INVALID_INPUT'}, f"Invalid folder. Needs to be inside your rda folder.")

--- a/io_annocfg/operators.py
+++ b/io_annocfg/operators.py
@@ -19,10 +19,10 @@ from typing import Tuple, List, NewType, Any, Union, Dict, Optional, TypeVar, Ty
 from . import feedback_enums
 from .simple_anno_feedback_encoding import SimpleAnnoFeedbackEncoding
 from .prefs import IO_AnnocfgPreferences
-from .anno_objects import get_anno_object_class, Transform, AnnoObject, MainFile, Model, SimpleAnnoFeedbackEncodingObject, \
-    SubFile, Decal, Propcontainer, Prop, Particle, IfoCube, IfoPlane, Sequence, DummyGroup, \
+from .anno_objects import get_anno_object_class, anno_object_classes, Transform, AnnoObject, MainFile, Model, SimpleAnnoFeedbackEncodingObject, \
+    SubFile, Decal, Propcontainer, Prop, Particle, IfoCube, IfoPlane, Sequence, DummyGroup, ArbitraryXMLAnnoObject, Material, \
     Dummy, Cf7DummyGroup, Cf7Dummy, FeedbackConfig, Light, IfoFile, Cf7File, IslandFile, PropGridInstance, IslandGamedataFile, AssetsXML,\
-    Animation, Cloth
+    Animation, Cloth, BezierCurve, GameObject, AnimationsNode, AnimationSequences, AnimationSequence, Track, TrackElement, IfoMeshHeightmap,BezierCurve,Spline
 
 
 from .utils import data_path_to_absolute_path, to_data_path
@@ -961,6 +961,9 @@ class ImportAllCfgsOperator(Operator, ImportHelper):
                     collection.asset_data.tags.new(directory)
             bpy.ops.ed.lib_id_generate_preview({"id": collection})
         return {"FINISHED"}
+
+
+
 
 classes = (
     ExportAnnoCfg,

--- a/io_annocfg/operators.py
+++ b/io_annocfg/operators.py
@@ -372,6 +372,16 @@ class ImportAnnoIsland(Operator, ImportHelper):
         options={'HIDDEN'},
         maxlen=255,  # Max internal buffer length, longer would be clamped.
     )
+    
+    prop_import: EnumProperty( #type: ignore
+        default="All",
+        items = [
+            ("All", "All", "Import all props"),
+            ("No Vegetation", "No Vegetation", ""),
+            ("None", "None", "Imports no props at all."),
+        ],
+        name = "Props"
+    )
 
     def execute(self, context):
         self.path = Path(self.filepath)
@@ -392,26 +402,57 @@ class ImportAnnoIsland(Operator, ImportHelper):
             self.report({'ERROR_INVALID_INPUT'}, f"Invalid file or extension")
             return {'CANCELLED'}
         
-        if "gamedata" in self.path.stem:
-            print(self.path.name, " is a gamedata island file.")
-            tree = ET.parse(self.path)
-            root = tree.getroot()
+        # if "gamedata" in self.path.stem:
+        #     print(self.path.name, " is a gamedata island file.")
+        #     tree = ET.parse(self.path)
+        #     root = tree.getroot()
             
-            assetsXML = AssetsXML()
+        #     assetsXML = AssetsXML()
             
-            file_obj = IslandGamedataFile.xml_to_blender(root, assetsXML)
+        #     file_obj = IslandGamedataFile.xml_to_blender(root, assetsXML)
             
-            self.report({'INFO'}, "Import completed!")
-            return {"FINISHED"}
+        #     self.report({'INFO'}, "Import completed!")
+        #     return {"FINISHED"}
         
         tree = ET.parse(self.path)
         root = tree.getroot()
         
-        file_obj = IslandFile.xml_to_blender(root)
+        file_obj = IslandFile.xml_to_blender(root, self.prop_import)
         file_obj.name = "ISLAND_" + self.path.name
 
         self.report({'INFO'}, "Import completed!")
         return {'FINISHED'}
+
+class ImportAnnoIslandGamedata(Operator, ImportHelper):
+    """Parses decoded Anno 1800 island gamedata xml files and loads them into blender."""
+    bl_idname = "import.anno_island_gamedata_files" 
+    bl_label = "Import Anno Island Gamedata Files (.xml)"
+
+    # ImportHelper mixin class uses this
+    filename_ext = ".xml"
+
+    filter_glob: StringProperty( #type:  ignore
+        default="*.xml",
+        options={'HIDDEN'},
+        maxlen=255,  # Max internal buffer length, longer would be clamped.
+    )
+
+    def execute(self, context):
+        self.path = Path(self.filepath)
+        
+        if not self.path.suffix == ".xml" or not self.path.exists():
+            self.report({'ERROR_INVALID_INPUT'}, f"Invalid file or extension")
+            return {'CANCELLED'}
+        tree = ET.parse(self.path)
+        root = tree.getroot()
+        
+        assetsXML = AssetsXML()
+        
+        file_obj = IslandGamedataFile.xml_to_blender(root, assetsXML)
+        
+        self.report({'INFO'}, "Import completed!")
+        return {"FINISHED"}
+
 
 class ExportAnnoIsland(Operator, ExportHelper):
     """Exports the prop grid elements of an island file. Not the heightmap, etc. Cannot handle new props (yet). Exports ALL objects in this scene, so do not load multiple islands at once."""
@@ -430,7 +471,7 @@ class ExportAnnoIsland(Operator, ExportHelper):
     def execute(self, context):
         self.path = Path(self.filepath)
         self.obj = context.active_object
-        if not self.obj or not get_anno_object_class(self.obj) in [IslandFile, IslandGamedataFile]:
+        if not self.obj or not get_anno_object_class(self.obj) in [IslandFile]:
             self.report({'ERROR_INVALID_CONTEXT'}, f"ISLAND_FILE object needs to be selected.")
             return {'CANCELLED'}
         
@@ -447,7 +488,45 @@ class ExportAnnoIsland(Operator, ExportHelper):
     def poll(cls, context):
         if not context.active_object:
             return False
-        return get_anno_object_class(context.active_object) in [IslandFile, IslandGamedataFile]
+        return get_anno_object_class(context.active_object) in [IslandFile]
+    
+    
+
+class ExportAnnoIslandGamedata(Operator, ExportHelper):
+    """Exports the IslandGamedata Objects. Exports ALL objects in this scene, so do not load multiple islands at once."""
+    bl_idname = "export.anno_island_gamedata_files" 
+    bl_label = "Export Anno Island Gamedata Files (.xml)"
+
+    # ImportHelper mixin class uses this
+    filename_ext = ".xml"
+
+    filter_glob: StringProperty( #type:  ignore
+        default="*.xml",
+        options={'HIDDEN'},
+        maxlen=255,  # Max internal buffer length, longer would be clamped.
+    )
+
+    def execute(self, context):
+        self.path = Path(self.filepath)
+        self.obj = context.active_object
+        if not self.obj or not get_anno_object_class(self.obj) in [IslandGamedataFile]:
+            self.report({'ERROR_INVALID_CONTEXT'}, f"ISLAND_FILE object needs to be selected.")
+            return {'CANCELLED'}
+        
+        root = get_anno_object_class(self.obj).blender_to_xml(self.obj)
+        if root is None:
+            return{'CANCELLED'}
+        tree = ET.ElementTree(root)
+        ET.indent(tree, space="\t", level=0)
+        tree.write(self.filepath)
+        self.report({'INFO'}, 'Island export completed.')
+        
+        return {'FINISHED'}
+    @classmethod
+    def poll(cls, context):
+        if not context.active_object:
+            return False
+        return get_anno_object_class(context.active_object) in [IslandGamedataFile]
     
 
 class ImportAnnoModelOperator(Operator, ImportHelper):
@@ -893,7 +972,9 @@ classes = (
     ImportAllPropsOperator,
     ImportAllCfgsOperator,
     ImportAnnoIsland,
+    ImportAnnoIslandGamedata,
     ExportAnnoIsland,
+    ExportAnnoIslandGamedata,
     # ExportAnimatedAnnoModelOperator,
 )
 
@@ -930,20 +1011,27 @@ def menu_func_import_all_cfgs(self, context):
 
 def menu_func_import_island(self, context):
     self.layout.operator(ImportAnnoIsland.bl_idname, text="Anno Island (.xml)")
+def menu_func_import_island_gamedata(self, context):
+    self.layout.operator(ImportAnnoIslandGamedata.bl_idname, text="Anno Island Gamedata (.xml)")
 
 def menu_func_export_island(self, context):
     self.layout.operator(ExportAnnoIsland.bl_idname, text="Anno Island (.xml)")
+
+def menu_func_export_island_gamedata(self, context):
+    self.layout.operator(ExportAnnoIslandGamedata.bl_idname, text="Anno Island Gamedata (.xml)")
 
 import_funcs = [
     menu_func_import,
     menu_func_import_model,
     menu_func_import_prop,
     menu_func_import_island,
+    menu_func_import_island_gamedata,
 ]
 export_funcs = [
     menu_func_export_cfg,
     menu_func_export_model,
     menu_func_export_island,
+    menu_func_export_island_gamedata,
     # menu_func_export_animation,
 ]
 

--- a/io_annocfg/prefs.py
+++ b/io_annocfg/prefs.py
@@ -17,7 +17,7 @@
 # ##### END GPL LICENSE BLOCK #####
 import bpy
 from bpy.types import AddonPreferences, Scene
-from bpy.props import StringProperty, EnumProperty, BoolProperty
+from bpy.props import StringProperty, EnumProperty, BoolProperty, FloatProperty
 
 from pathlib import Path
 
@@ -72,6 +72,25 @@ class IO_AnnocfgPreferences(AddonPreferences):
         description = "Turns sequences into blender objects and resolves ModelID (and ParticleID) references to their respective blender object. Allows easier handling of animated files and prevents errors coming from a reordering of the models when exporting. ",
         default = True
     )
+    cfg_cache_probability_float : FloatProperty( # type: ignore
+        name = "Cfg Cache Probability",
+        description = "Caches .cfg files in a specific library folder to allow faster retrieval. Set to 0 to disable and to 1 to cache everything. Use a value in between to only cache frequently used .cfgs (in expectation)",
+        default = 1.0,
+        min = 0.0,
+        max = 1.0,
+    )
+    cfg_cache_loading_enabled_bool : BoolProperty( # type: ignore
+        name = "Cfg Cache Loading Enabled",
+        description = "Allow to load cached .cfgs",
+        default = True,
+    )
+    cfg_cache_path : StringProperty( # type: ignore
+        name = "Path to cfg cache",
+        description = "Select a Path for the cfg Cache. Sadly it does not work great as an asset library, because it lacks preview images...",
+        subtype='FILE_PATH',
+        default = "C:\\Users\\Public\\Anno\\CfgCache",
+    )
+    
     def draw(self, context):
         layout = self.layout
         layout.prop(self, "path_to_rda_folder")
@@ -82,7 +101,13 @@ class IO_AnnocfgPreferences(AddonPreferences):
         layout.prop(self, "mirror_models_bool")
         layout.prop(self, "enable_splines")
         layout.prop(self, "sequences_as_blender_objects")
+        layout.prop(self, "cfg_cache_loading_enabled_bool")
+        layout.prop(self, "cfg_cache_probability_float")
+        layout.prop(self, "cfg_cache_path")
 
+    @classmethod
+    def get_cfg_cache_path(cls):
+        return Path(bpy.context.preferences.addons[__package__].preferences.cfg_cache_path)
     @classmethod
     def get_path_to_rda_folder(cls):
         return Path(bpy.context.preferences.addons[__package__].preferences.path_to_rda_folder)
@@ -107,6 +132,12 @@ class IO_AnnocfgPreferences(AddonPreferences):
     @classmethod
     def turn_sequences_into_blender_objects(cls):
         return bpy.context.preferences.addons[__package__].preferences.sequences_as_blender_objects
+    @classmethod
+    def cfg_cache_probability(cls):
+        return bpy.context.preferences.addons[__package__].preferences.cfg_cache_probability_float
+    @classmethod
+    def cfg_cache_loading_enabled(cls):
+        return bpy.context.preferences.addons[__package__].preferences.cfg_cache_loading_enabled_bool
 
 classes = (
     IO_AnnocfgPreferences,

--- a/io_annocfg/transform.py
+++ b/io_annocfg/transform.py
@@ -120,17 +120,17 @@ class Transform:
         
         self.anno_coords
     
-    def mirror_mesh(self, object):
+    @classmethod
+    def mirror_mesh(self, obj):
         if not IO_AnnocfgPreferences.mirror_models():
             return
-        if not object.data or not hasattr(object.data, "vertices"):
+        if not obj.data or not hasattr(obj.data, "vertices"):
             return
-        for v in object.data.vertices:
+        for v in obj.data.vertices:
             v.co.x *= -1.0
-            
         #Inverting normals for import AND Export they are wrong because of scaling on the x axis.
         #Warn people that this will break exports from .blend files made with an earlier version!!!
-        mesh = object.data
+        mesh = obj.data
         bm = bmesh.new()
         bm.from_mesh(mesh) # load bmesh
         for f in bm.faces:
@@ -143,7 +143,7 @@ class Transform:
     def apply_to(self, object):
         if self.anno_coords:
             self.convert_to_blender_coords()
-        self.mirror_mesh(object)
+        #self.mirror_mesh(object)
         object.location = self.location
         if not self.euler_rotation:
             object.rotation_mode = "QUATERNION"


### PR DESCRIPTION

- Can now convert XML code from the clipboard into blender anno objects by clicking the button in the anno object tab. It requires you to correctly choose the right object type.
- Can convert an individual blender anno object to XML (and store it in your clipboard). [Note that fields that are a reference to some other blender object (BlenderModelID) cannot be resolved]
- Supports BONELINK Transforms: The modelID will be converted in an object link and converted back to the model index after exporting.

Caching: 
You can give a cache directory to which the addon can save complete .cfg files for caching. This is especially useful if you want to load large gamedata files of islands. The cache is invalidated if the respective .cfg file gets modified. However, it does *not* invalidate if the .cfg of a subfile is modified. In that case, you'll need to delete the entries from the cache manually.
Three parameters in the settings: The path to the cache folder, an option to deactivate the cache and a probability to store a .cfg in a cache.

Islands:
- Option to import only a subset of props (f.e. no vegetation)
- FILE objects can be converted to GameObjects
- Supports BezierCurves for GameObjects. Only supports p, i, o, not u0 and w. Ignores all curves with these parameters.

Bugfix:
- Props are now correctly mirrored
- Will only use an existing texture of the same name if it is actually the same texture.